### PR TITLE
Additional fixes for PHP8.1

### DIFF
--- a/lib/generator/sfModelGenerator.class.php
+++ b/lib/generator/sfModelGenerator.class.php
@@ -273,7 +273,7 @@ EOF;
     }
     else if ('Date' == $field->getType())
     {
-      $html = sprintf("false !== strtotime($html) ? format_date(%s, \"%s\") : '&nbsp;'", $html, $field->getConfig('date_format', 'f'));
+      $html = sprintf("is_string($html) && false !== strtotime($html) ? format_date(%s, \"%s\") : '&nbsp;'", $html, $field->getConfig('date_format', 'f'));
     }
     else if ('Boolean' == $field->getType())
     {

--- a/lib/request/sfWebRequest.class.php
+++ b/lib/request/sfWebRequest.class.php
@@ -872,6 +872,9 @@ class sfWebRequest extends sfRequest
    */
   static protected function fixPhpFilesArray(array $data)
   {
+    // remove full_path added on php8.1
+    unset($data['full_path']);
+
     $fileKeys = array('error', 'name', 'size', 'tmp_name', 'type');
     $keys = array_keys($data);
     sort($keys);

--- a/lib/util/sfBrowserBase.class.php
+++ b/lib/util/sfBrowserBase.class.php
@@ -911,7 +911,7 @@ abstract class sfBrowserBase
     }
     else
     {
-      $queryString = is_array($arguments) ? http_build_query($arguments, null, '&') : '';
+      $queryString = is_array($arguments) ? http_build_query($arguments, '', '&') : '';
       $sep = false === strpos($url, '?') ? '?' : '&';
 
       return array($url.($queryString ? $sep.$queryString : ''), 'get', array());

--- a/lib/view/sfViewCacheManager.class.php
+++ b/lib/view/sfViewCacheManager.class.php
@@ -1003,10 +1003,10 @@ class sfViewCacheManager
   {
     $cacheKey = $this->routing->getCurrentInternalUri();
 
-    if ($getParameters = $this->request->getGetParameters())
+    if ($cacheKey && $getParameters = $this->request->getGetParameters())
     {
       $cacheKey .= false === strpos($cacheKey, '?') ? '?' : '&';
-      $cacheKey .= http_build_query($getParameters, null, '&');
+      $cacheKey .= http_build_query($getParameters, '', '&');
     }
 
     return $cacheKey;

--- a/test/unit/sfNoRouting.class.php
+++ b/test/unit/sfNoRouting.class.php
@@ -29,7 +29,7 @@ class sfNoRouting extends sfRouting
     // other parameters
     unset($parameters['module'], $parameters['action']);
     ksort($parameters);
-    $parameters = count($parameters) ? '?'.http_build_query($parameters, null, '&') : '';
+    $parameters = count($parameters) ? '?'.http_build_query($parameters, '', '&') : '';
 
     return sprintf('%s%s', $action, $parameters);
   }
@@ -49,7 +49,7 @@ class sfNoRouting extends sfRouting
       unset($parameters['action']);
     }
 
-    $parameters = http_build_query($parameters, null, '&');
+    $parameters = http_build_query($parameters, '', '&');
 
     return $this->fixGeneratedUrl('/'.($parameters ? '?'.$parameters : ''), $absolute);
   }


### PR DESCRIPTION
On PHP8.1, file uploads have a new [`full_path`](https://php.watch/versions/8.1/$_FILES-full-path)  parameter which symfony1 forms don't recognize and creates all sort of form validation errors. [Following symfony2+](https://github.com/symfony/symfony/pull/42112/files), we can simply unset it. If one truly needs to use it, it can be obtained from `$_FILES`.

Also, a few more fixes for uses of null where string is expected.